### PR TITLE
CGEvent return with Unmanaged.passUnretained

### DIFF
--- a/cmd-eikana/KeyEvent.swift
+++ b/cmd-eikana/KeyEvent.swift
@@ -99,7 +99,7 @@ class KeyEvent: NSObject {
                     let mySelf = Unmanaged<KeyEvent>.fromOpaque(observer).takeUnretainedValue()
                     return mySelf.eventCallback(proxy: proxy, type: type, event: event)
                 }
-                return Unmanaged.passRetained(event)
+                return Unmanaged.passUnretained(event)
             },
             userInfo: observer
             ) else {
@@ -116,7 +116,7 @@ class KeyEvent: NSObject {
     
     func eventCallback(proxy: CGEventTapProxy, type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         if isExclusionApp {
-            return Unmanaged.passRetained(event)
+            return Unmanaged.passUnretained(event)
         }
         
         if let mediaKeyEvent = MediaKeyEvent(event) {
@@ -128,7 +128,7 @@ class KeyEvent: NSObject {
             let keyCode = CGKeyCode(event.getIntegerValueField(.keyboardEventKeycode))
             
             if modifierMasks[keyCode] == nil {
-                return Unmanaged.passRetained(event)
+                return Unmanaged.passUnretained(event)
             }
             return event.flags.rawValue & modifierMasks[keyCode]!.rawValue != 0 ?
                 modifierKeyDown(event) : modifierKeyUp(event)
@@ -142,7 +142,7 @@ class KeyEvent: NSObject {
         default:
             self.keyCode = nil
             
-            return Unmanaged.passRetained(event)
+            return Unmanaged.passUnretained(event)
         }
     }
     
@@ -162,20 +162,20 @@ class KeyEvent: NSObject {
         }
         
         if let event = getConvertedEvent(event) {
-            return Unmanaged.passRetained(event)
+            return Unmanaged.passUnretained(event)
         }
         
-        return Unmanaged.passRetained(event)
+        return Unmanaged.passUnretained(event)
     }
     
     func keyUp(_ event: CGEvent) -> Unmanaged<CGEvent>? {
         self.keyCode = nil
         
         if let event = getConvertedEvent(event) {
-            return Unmanaged.passRetained(event)
+            return Unmanaged.passUnretained(event)
         }
         
-        return Unmanaged.passRetained(event)
+        return Unmanaged.passUnretained(event)
     }
     
     func modifierKeyDown(_ event: CGEvent) -> Unmanaged<CGEvent>? {
@@ -192,7 +192,7 @@ class KeyEvent: NSObject {
             keyTextField.stringValue = shortcut.toString()
         }
         
-        return Unmanaged.passRetained(event)
+        return Unmanaged.passUnretained(event)
     }
     
     func modifierKeyUp(_ event: CGEvent) -> Unmanaged<CGEvent>? {
@@ -207,7 +207,7 @@ class KeyEvent: NSObject {
         
         self.keyCode = nil
         
-        return Unmanaged.passRetained(event)
+        return Unmanaged.passUnretained(event)
     }
     
     func mediaKeyDown(_ mediaKeyEvent: MediaKeyEvent) -> Unmanaged<CGEvent>? {
@@ -233,7 +233,7 @@ class KeyEvent: NSObject {
             return nil
         }
         
-        return Unmanaged.passRetained(mediaKeyEvent.event)
+        return Unmanaged.passUnretained(mediaKeyEvent.event)
     }
     func mediaKeyUp(_ mediaKeyEvent: MediaKeyEvent) -> Unmanaged<CGEvent>? {
         
@@ -242,7 +242,7 @@ class KeyEvent: NSObject {
             return nil
         }
         
-        return Unmanaged.passRetained(mediaKeyEvent.event)
+        return Unmanaged.passUnretained(mediaKeyEvent.event)
     }
     
     func getConvertedEvent(_ event: CGEvent, keyCode: CGKeyCode? = nil, keyDown: Bool = false) -> CGEvent? {


### PR DESCRIPTION
日本語で失礼します。

https://developer.apple.com/reference/coregraphics/cgeventtapcallback の discussion を読む限り、渡ってきた event はそのまま retain せず返せば良いのかなという気がしています。おそらくここで retain すると解放されずにメモリリークになりそうです。