### PR TITLE
GitHub Actionsの新しいワークフローを追加

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,17 @@
+name: xcodebuild
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  build-on-mac:
+    name: Build on macOS
+    runs-on: [macos-12, macos-11, macos-10.15]
+    steps:
+      - uses: actions/checkout@v3
+      - run: swift --version
+      - run: xcodebuild -project ⌘英かな.xcodeproj -config Release


### PR DESCRIPTION
- GitHub Actions上でソースコードがビルド可能かを試すワークフローを追加します。
- それぞれのOSでの正常な動作を保証するわけではないですが、最低限ビルドが通ることが保証できることの意味はあるかと思います。